### PR TITLE
Replace hardcoded database prefix and add a config option to disable tracking product views

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,12 @@
+# EditorConfig is awesome: https://EditorConfig.org
+
+# top-most EditorConfig file
+root = true
+
+[*]
+indent_style = space
+indent_size = 4
+end_of_line = lf
+charset = utf-8
+trim_trailing_whitespace = true
+insert_final_newline = false

--- a/.editorconfig
+++ b/.editorconfig
@@ -1,12 +1,33 @@
-# EditorConfig is awesome: https://EditorConfig.org
-
-# top-most EditorConfig file
 root = true
 
 [*]
 indent_style = space
 indent_size = 4
-end_of_line = lf
 charset = utf-8
+end_of_line = lf
 trim_trailing_whitespace = true
-insert_final_newline = false
+insert_final_newline = true
+
+[*.json]
+indent_style = space
+indent_size = 2
+
+[*.sh]
+indent_style = tab
+indent_size = 4
+
+[*.md]
+trim_trailing_whitespace = false
+
+[*.{yml,yaml,js,ts,vue,blade.php,lua}]
+indent_style = space
+indent_size = 2
+
+[docker-compose{,.*}.{yaml,yml}]
+indent_style = space
+indent_size = 4
+trim_trailing_whitespace = false
+
+[Dockerfile,Makefile]
+indent_style = tab
+indent_size = 4

--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,4 @@ ray.php
 _ide_helper.php
 .phpactor.json
 .env.testing
+/.vscode/launch.json

--- a/composer.json
+++ b/composer.json
@@ -1,84 +1,83 @@
 {
-    "name": "dystcz/lunar-api",
-    "description": "Lunar API",
-    "keywords": [
-        "dystcz",
-        "lunar",
-        "lunar-api",
-        "laravel",
-        "php"
-    ],
-    "homepage": "https://github.com/dystcz/lunar-api",
-    "license": "MIT",
-    "type": "library",
-    "authors": [
-        {
-            "name": "Jakub Theimer",
-            "email": "jakub@dy.st",
-            "role": "Developer"
-        }
-    ],
-    "require": {
-        "php": "^8.1",
-        "ext-redis": "*",
-        "dystcz/lunar-paypal": "dev-main",
-        "illuminate/support": "^10.0",
-        "laravel-json-api/laravel": "^3.0",
-        "laravel-json-api/non-eloquent": "^3.0",
-        "lunarphp/lunar": "^0.3.0-beta",
-        "lunarphp/stripe": "0.3.x-dev",
-        "spatie/laravel-query-builder": "^5.2"
-    },
-    "require-dev": {
-        "barryvdh/laravel-ide-helper": "^2.13",
-        "driftingly/rector-laravel": "^0.17.0",
-        "laravel-json-api/testing": "^2.1",
-        "laravel/pint": "^1.7",
-        "nunomaduro/larastan": "^2.5.1",
-        "orchestra/testbench": "^8.0",
-        "pestphp/pest": "^2.0",
-        "pestphp/pest-plugin-laravel": "^2.0",
-        "rector/rector": "^0.15.23",
-        "spatie/laravel-ray": "^1.32"
-    },
-    "autoload": {
-        "psr-4": {
-            "Dystcz\\LunarApi\\": "src"
-        }
-    },
-    "autoload-dev": {
-        "psr-4": {
-            "Dystcz\\LunarApi\\Tests\\": "tests"
-        }
-    },
-    "scripts": {
-        "test": "vendor/bin/pest",
-        "test-coverage": "vendor/bin/pest --coverage-html coverage",
-        "analyse": "vendor/bin/phpstan analyse"
-    },
-    "config": {
-        "sort-packages": true,
-        "allow-plugins": {
-            "pestphp/pest-plugin": true
-        }
-    },
-    "repositories": [
-        {
-            "type": "vcs",
-            "url": "https://github.com/dystcz/lunar-paypal.git"
-        }
-    ],
-    "extra": {
-        "laravel": {
-            "providers": [
-                "Dystcz\\LunarApi\\LunarApiServiceProvider",
-                "Dystcz\\LunarApi\\JsonApiServiceProvider"
-            ],
-            "aliases": {
-                "LunarApi": "Dystcz\\LunarApi\\Facade\\LunarApi"
-            }
-        }
-    },
-    "minimum-stability": "dev",
-    "prefer-stable": true
+  "name": "dystcz/lunar-api",
+  "description": "Lunar API",
+  "keywords": [
+    "dystcz",
+    "lunar",
+    "lunar-api",
+    "laravel",
+    "php"
+  ],
+  "homepage": "https://github.com/dystcz/lunar-api",
+  "license": "MIT",
+  "type": "library",
+  "authors": [
+    {
+      "name": "Jakub Theimer",
+      "email": "jakub@dy.st",
+      "role": "Developer"
+    }
+  ],
+  "require": {
+    "php": "^8.1",
+    "ext-redis": "*",
+    "illuminate/support": "^10.0",
+    "laravel-json-api/laravel": "^3.0",
+    "laravel-json-api/non-eloquent": "^3.0",
+    "lunarphp/lunar": "^0.3.0-beta",
+    "lunarphp/stripe": "0.3.x-dev",
+    "spatie/laravel-query-builder": "^5.2"
+  },
+  "require-dev": {
+    "barryvdh/laravel-ide-helper": "^2.13",
+    "driftingly/rector-laravel": "^0.17.0",
+    "laravel-json-api/testing": "^2.1",
+    "laravel/pint": "^1.7",
+    "nunomaduro/larastan": "^2.5.1",
+    "orchestra/testbench": "^8.0",
+    "pestphp/pest": "^2.0",
+    "pestphp/pest-plugin-laravel": "^2.0",
+    "rector/rector": "^0.15.23",
+    "spatie/laravel-ray": "^1.32"
+  },
+  "autoload": {
+    "psr-4": {
+      "Dystcz\\LunarApi\\": "src"
+    }
+  },
+  "autoload-dev": {
+    "psr-4": {
+      "Dystcz\\LunarApi\\Tests\\": "tests"
+    }
+  },
+  "scripts": {
+    "test": "vendor/bin/pest",
+    "test-coverage": "vendor/bin/pest --coverage-html coverage",
+    "analyse": "vendor/bin/phpstan analyse"
+  },
+  "config": {
+    "sort-packages": true,
+    "allow-plugins": {
+      "pestphp/pest-plugin": true
+    }
+  },
+  "repositories": [
+    {
+      "type": "vcs",
+      "url": "https://github.com/dystcz/lunar-paypal.git"
+    }
+  ],
+  "extra": {
+    "laravel": {
+      "providers": [
+        "Dystcz\\LunarApi\\LunarApiServiceProvider",
+        "Dystcz\\LunarApi\\JsonApiServiceProvider"
+      ],
+      "aliases": {
+        "LunarApi": "Dystcz\\LunarApi\\Facade\\LunarApi"
+      }
+    }
+  },
+  "minimum-stability": "dev",
+  "prefer-stable": true
 }

--- a/composer.json
+++ b/composer.json
@@ -1,83 +1,82 @@
 {
-  "name": "dystcz/lunar-api",
-  "description": "Lunar API",
-  "keywords": [
-    "dystcz",
-    "lunar",
-    "lunar-api",
-    "laravel",
-    "php"
-  ],
-  "homepage": "https://github.com/dystcz/lunar-api",
-  "license": "MIT",
-  "type": "library",
-  "authors": [
-    {
-      "name": "Jakub Theimer",
-      "email": "jakub@dy.st",
-      "role": "Developer"
-    }
-  ],
-  "require": {
-    "php": "^8.1",
-    "ext-redis": "*",
-    "illuminate/support": "^10.0",
-    "laravel-json-api/laravel": "^3.0",
-    "laravel-json-api/non-eloquent": "^3.0",
-    "lunarphp/lunar": "^0.3.0-beta",
-    "lunarphp/stripe": "0.3.x-dev",
-    "spatie/laravel-query-builder": "^5.2"
-  },
-  "require-dev": {
-    "barryvdh/laravel-ide-helper": "^2.13",
-    "driftingly/rector-laravel": "^0.17.0",
-    "laravel-json-api/testing": "^2.1",
-    "laravel/pint": "^1.7",
-    "nunomaduro/larastan": "^2.5.1",
-    "orchestra/testbench": "^8.0",
-    "pestphp/pest": "^2.0",
-    "pestphp/pest-plugin-laravel": "^2.0",
-    "rector/rector": "^0.15.23",
-    "spatie/laravel-ray": "^1.32"
-  },
-  "autoload": {
-    "psr-4": {
-      "Dystcz\\LunarApi\\": "src"
-    }
-  },
-  "autoload-dev": {
-    "psr-4": {
-      "Dystcz\\LunarApi\\Tests\\": "tests"
-    }
-  },
-  "scripts": {
-    "test": "vendor/bin/pest",
-    "test-coverage": "vendor/bin/pest --coverage-html coverage",
-    "analyse": "vendor/bin/phpstan analyse"
-  },
-  "config": {
-    "sort-packages": true,
-    "allow-plugins": {
-      "pestphp/pest-plugin": true
-    }
-  },
-  "repositories": [
-    {
-      "type": "vcs",
-      "url": "https://github.com/dystcz/lunar-paypal.git"
-    }
-  ],
-  "extra": {
-    "laravel": {
-      "providers": [
-        "Dystcz\\LunarApi\\LunarApiServiceProvider",
-        "Dystcz\\LunarApi\\JsonApiServiceProvider"
-      ],
-      "aliases": {
-        "LunarApi": "Dystcz\\LunarApi\\Facade\\LunarApi"
-      }
-    }
-  },
-  "minimum-stability": "dev",
-  "prefer-stable": true
+    "name": "dystcz/lunar-api",
+    "description": "Lunar API",
+    "keywords": [
+        "dystcz",
+        "lunar",
+        "lunar-api",
+        "laravel",
+        "php"
+    ],
+    "homepage": "https://github.com/dystcz/lunar-api",
+    "license": "MIT",
+    "type": "library",
+    "authors": [
+        {
+            "name": "Jakub Theimer",
+            "email": "jakub@dy.st",
+            "role": "Developer"
+        }
+    ],
+    "require": {
+        "php": "^8.1",
+        "ext-redis": "*",
+        "illuminate/support": "^10.0",
+        "laravel-json-api/laravel": "^3.0",
+        "laravel-json-api/non-eloquent": "^3.0",
+        "lunarphp/lunar": "^0.3.0-beta",
+        "spatie/laravel-query-builder": "^5.2"
+    },
+    "require-dev": {
+        "barryvdh/laravel-ide-helper": "^2.13",
+        "driftingly/rector-laravel": "^0.17.0",
+        "laravel-json-api/testing": "^2.1",
+        "laravel/pint": "^1.7",
+        "nunomaduro/larastan": "^2.5.1",
+        "orchestra/testbench": "^8.0",
+        "pestphp/pest": "^2.0",
+        "pestphp/pest-plugin-laravel": "^2.0",
+        "rector/rector": "^0.15.23",
+        "spatie/laravel-ray": "^1.32"
+    },
+    "autoload": {
+        "psr-4": {
+            "Dystcz\\LunarApi\\": "src"
+        }
+    },
+    "autoload-dev": {
+        "psr-4": {
+            "Dystcz\\LunarApi\\Tests\\": "tests"
+        }
+    },
+    "scripts": {
+        "test": "vendor/bin/pest",
+        "test-coverage": "vendor/bin/pest --coverage-html coverage",
+        "analyse": "vendor/bin/phpstan analyse"
+    },
+    "config": {
+        "sort-packages": true,
+        "allow-plugins": {
+            "pestphp/pest-plugin": true
+        }
+    },
+    "repositories": [
+        {
+            "type": "vcs",
+            "url": "https://github.com/dystcz/lunar-paypal.git"
+        }
+    ],
+    "extra": {
+        "laravel": {
+            "providers": [
+                "Dystcz\\LunarApi\\LunarApiServiceProvider",
+                "Dystcz\\LunarApi\\JsonApiServiceProvider"
+            ],
+            "aliases": {
+                "LunarApi": "Dystcz\\LunarApi\\Facade\\LunarApi"
+            }
+        }
+    },
+    "minimum-stability": "dev",
+    "prefer-stable": true
 }

--- a/config/lunar-api.php
+++ b/config/lunar-api.php
@@ -18,6 +18,9 @@ return [
         //
     ],
 
+    // Enable product views tracking
+    'track_product_views' => true,
+
     'auth' => [
         'actions' => [
             'create_user_from_cart' => Dystcz\LunarApi\Domain\Carts\Actions\CreateUserFromCart::class,

--- a/pint.json
+++ b/pint.json
@@ -1,6 +1,6 @@
 {
-    "preset": "laravel",
-    "rules": {
-        "explicit_string_variable": true
-    }
+  "preset": "laravel",
+  "rules": {
+    "explicit_string_variable": true
+  }
 }

--- a/src/Domain/ProductVariants/Models/ProductVariant.php
+++ b/src/Domain/ProductVariants/Models/ProductVariant.php
@@ -45,9 +45,11 @@ class ProductVariant extends LunarPoductVariant
     {
         // TODO: Not working, finish
         return $this->product->morphOne(config('media-library.media_model'), 'model')
-            ->where(function ($query) {
-                $query->where('id', function ($q) {
-                    return $q->from('dystore_media_product_variant')
+        ->where(function ($query) {
+            $query->where('id', function ($q) {
+                    $prefix = config('lunar.database.table_prefix');
+
+                    return $q->from("{$prefix}media_product_variant")
                         ->select('media_id')
                         ->where('product_variant_id', $this->getKey())
                         ->where('primary', true)

--- a/src/Domain/ProductVariants/Models/ProductVariant.php
+++ b/src/Domain/ProductVariants/Models/ProductVariant.php
@@ -6,6 +6,7 @@ use Dystcz\LunarApi\Domain\ProductVariants\Enums\PurchaseStatus;
 use Dystcz\LunarApi\Domain\ProductVariants\Factories\ProductVariantFactory;
 use Illuminate\Database\Eloquent\Casts\Attribute;
 use Illuminate\Database\Eloquent\Relations\MorphOne;
+use Illuminate\Support\Facades\Config;
 use InvalidArgumentException;
 use Lunar\Models\Price as LunarPrice;
 use Lunar\Models\ProductVariant as LunarPoductVariant;
@@ -47,7 +48,7 @@ class ProductVariant extends LunarPoductVariant
         return $this->product->morphOne(config('media-library.media_model'), 'model')
         ->where(function ($query) {
             $query->where('id', function ($q) {
-                    $prefix = config('lunar.database.table_prefix');
+                    $prefix = Config::get('lunar.database.table_prefix');
 
                     return $q->from("{$prefix}media_product_variant")
                         ->select('media_id')

--- a/src/Domain/Products/JsonApi/Filters/ProductFilterCollection.php
+++ b/src/Domain/Products/JsonApi/Filters/ProductFilterCollection.php
@@ -14,7 +14,6 @@ class ProductFilterCollection implements FilterCollection
      */
     public function toArray(): array
     {
-        // TODO: Cache
         $attributes = Attribute::query()
             ->where('attribute_type', Product::class)
             ->where('filterable', true)

--- a/src/Domain/Products/JsonApi/V1/ProductSchema.php
+++ b/src/Domain/Products/JsonApi/V1/ProductSchema.php
@@ -6,6 +6,7 @@ use Dystcz\LunarApi\Domain\JsonApi\Contracts\FilterCollection;
 use Dystcz\LunarApi\Domain\JsonApi\Eloquent\Fields\AttributeData;
 use Dystcz\LunarApi\Domain\JsonApi\Eloquent\Schema;
 use Dystcz\LunarApi\Domain\Products\JsonApi\Sorts\RecentlyViewedSort;
+use Illuminate\Support\Facades\Config;
 use LaravelJsonApi\Eloquent\Fields\ID;
 use LaravelJsonApi\Eloquent\Fields\Relations\BelongsTo;
 use LaravelJsonApi\Eloquent\Fields\Relations\HasMany;
@@ -196,7 +197,7 @@ class ProductSchema extends Schema
     public function filters(): array
     {
         /** @var FilterCollection $filterCollection */
-        // $filterCollection = Config::get('lunar-api.domains.products.filters');
+        $filterCollection = Config::get('lunar-api.domains.products.filters');
 
         return [
             WhereIdIn::make($this),
@@ -205,9 +206,9 @@ class ProductSchema extends Schema
 
             WhereHas::make($this, 'brand'),
 
-            WhereHas::make($this, 'default_url', 'url')->singular(),
+            WhereHas::make($this, 'urls'),
 
-            // ...(new $filterCollection)->toArray(),
+            ...(new $filterCollection)->toArray(),
 
             ...parent::filters(),
         ];

--- a/src/Domain/Products/ProductViews.php
+++ b/src/Domain/Products/ProductViews.php
@@ -2,6 +2,7 @@
 
 namespace Dystcz\LunarApi\Domain\Products;
 
+use Illuminate\Support\Facades\Config;
 use Illuminate\Support\Facades\Redis;
 use Illuminate\Support\Str;
 
@@ -12,7 +13,7 @@ class ProductViews
      */
     public function enabled(): bool
     {
-        $enabled = config('lunar-api.track_product_views');
+        $enabled = Config::get('lunar-api.track_product_views');
 
         return $enabled === true;
     }

--- a/src/Domain/Products/ProductViews.php
+++ b/src/Domain/Products/ProductViews.php
@@ -8,6 +8,16 @@ use Illuminate\Support\Str;
 class ProductViews
 {
     /**
+     * Check if tracking product-view is enabled.
+     */
+    public function enabled(): bool
+    {
+        $enabled = config('lunar-api.track_product_views');
+
+        return $enabled === true;
+    }
+
+    /**
      * Lists of list of products views.
      */
     public function getLists(): array
@@ -23,6 +33,10 @@ class ProductViews
      */
     public function sorted(): array
     {
+        if (! $this->enabled()) {
+            return;
+        }
+
         $lists = $this->getLists();
 
         $sorted = collect();
@@ -44,6 +58,10 @@ class ProductViews
      */
     public function record(int $productId): void
     {
+        if (! $this->enabled()) {
+            return;
+        }
+
         Redis::zAdd("product:views:{$productId}", time(), Str::uuid()->toString());
 
         $this->removeOldEntries();

--- a/src/Domain/Products/ProductViews.php
+++ b/src/Domain/Products/ProductViews.php
@@ -33,10 +33,6 @@ class ProductViews
      */
     public function sorted(): array
     {
-        if (! $this->enabled()) {
-            return;
-        }
-
         $lists = $this->getLists();
 
         $sorted = collect();

--- a/src/Routing/Middleware/TokenBasedCartSessionMiddleware.php
+++ b/src/Routing/Middleware/TokenBasedCartSessionMiddleware.php
@@ -1,0 +1,149 @@
+<?php
+
+namespace Dystcz\LunarApi\Routing\Middleware;
+
+use Closure;
+use Dystcz\LunarApi\Domain\Carts\Models\Cart;
+use Illuminate\Http\Response;
+use Illuminate\Support\Str;
+use Lunar\Facades\CartSession;
+
+class TokenBasedCartSessionMiddleware
+{
+    /**
+     * List of routes which should be handled by this middleware
+     */
+    public function getRoutes(): array
+    {
+        return [
+            'v1.carts.myCart',
+            'v1.carts.applyCoupon',
+            'v1.carts.checkout',
+            'v1.carts.clear',
+            'v1.cart-lines.store',
+            'v1.cart-lines.update',
+            'v1.cart-lines.destroy',
+            'v1.shipping-options.index',
+        ];
+    }
+
+    public function handle($request, Closure $next)
+    {
+        /**
+         * Early return if the route is not in the list
+         */
+        if (! in_array($request->route()->getName(), $this->getRoutes())) {
+            return $next($request);
+        }
+
+        $token = $this->getToken($request);
+
+        /**
+         * If the token is not present, we create a new cart and return the token in the response header X-Cart-Token
+         */
+        if (! $token) {
+
+            $token = $this->createCartWithToken();
+
+            $response = $next($request);
+
+            $response = $this->setToken($response, $token);
+
+            return $response;
+        }
+
+        /**
+         * If the token is present, we try to find the cart by the token
+         */
+        $cart = $this->findCartByToken($token);
+
+        /**
+         * If the cart is not found, we create a new cart and return the token in the response header X-Cart-Token
+         */
+        if (! $cart === null) {
+
+            $response = $next($request);
+            $response->header('X-Cart-Token', $cart->meta->token);
+
+            return $next($request);
+        }
+
+        /**
+         * If the cart is found, we use it as the current cart
+         */
+        CartSession::use($cart);
+
+        /**
+         * We return the response
+         */
+        return $next($request);
+    }
+
+    /**
+     * Find a cart by the token
+     *
+     * @param  string  $token The token
+     * @return Cart|null The cart or null if not found
+     */
+    public function findCartByToken(string $token): ?Cart
+    {
+        return Cart::where('meta->token', $token)->first();
+    }
+
+    /**
+     * Generate a token
+     *
+     * @return string The token
+     */
+    public function generateToken(): string
+    {
+        return Str::random(40);
+    }
+
+    /**
+     * Get the token from the request header X-Cart-Token
+     *
+     * @param  Request  $request The request object
+     * @return string|null The token or null if not found
+     */
+    public function getToken($request): ?string
+    {
+        return $request->header('X-Cart-Token', null);
+    }
+
+    /**
+     * Set the token in the response header X-Cart-Token
+     *
+     * @param  Response  $response The response object
+     * @param $token The token
+     * @return Response The response object
+     */
+    public function setToken(Response $response, $token): Response
+    {
+        $response->headers->set('X-Cart-Token', $token);
+
+        return $response;
+    }
+
+    /**
+     * Create a new cart and return the token
+     *
+     * @return string The token created for the cart
+     */
+    public function createCartWithToken(): string
+    {
+        $cart = CartSession::current();
+
+        $token = $this->generateToken();
+
+        $meta = $cart->meta ?? [];
+
+        $meta['token'] = $token;
+
+        $cart->meta = $meta;
+
+        $cart->save();
+
+        return $token;
+    }
+}

--- a/src/Routing/Middleware/TokenBasedCartSessionMiddleware.php
+++ b/src/Routing/Middleware/TokenBasedCartSessionMiddleware.php
@@ -136,9 +136,9 @@ class TokenBasedCartSessionMiddleware
 
         $token = $this->generateToken();
 
-        $meta = $cart->meta ?? [];
+        $meta = (object) $cart->meta;
 
-        $meta['token'] = $token;
+        $meta->token = $token;
 
         $cart->meta = $meta;
 


### PR DESCRIPTION
Hey there!

This fix updates the `dystore_` prefix to the one configured in Lunar. Additionally, `/.vscode/launch.json` is added to the gitignore.

No test was included in this merge request as the change is minor.

Thanks,
Thomas