### PR TITLE
Update product options

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,16 @@
 -   Fixed dynamic relationships
 -   Added configurable auth guard `/Dystcz/LunarApi/Facades/LunarApi::authGuard($guard)`
 -   Updated policies to grant more privileges to Filament admins
+-   Added `product_options` relationship for `products`
+
+### ⚠️ Breaking changes
+
+1. Changed relationship names.
+
+    **Relationships:**
+
+    `product_options.values` → `product_options.product_option_values`<br>
+    `product_variants.values` → `product_variants.product_option_values`<br>
 
 ## 1.0.0-beta.1
 

--- a/src/Domain/ProductOptionValues/JsonApi/V1/ProductOptionValueSchema.php
+++ b/src/Domain/ProductOptionValues/JsonApi/V1/ProductOptionValueSchema.php
@@ -40,9 +40,12 @@ class ProductOptionValueSchema extends Schema
                     fn (ProductOptionValue $model, string $attribute) => $model->translate($attribute),
                 ),
 
-            BelongsTo::make('option', 'option')
+            BelongsTo::make('product_option', 'option')
                 ->readOnly()
-                ->type(SchemaType::get(ProductOption::class)),
+                ->type(SchemaType::get(ProductOption::class))
+                ->serializeUsing(
+                    static fn ($relation) => $relation->withoutLinks()
+                ),
 
             ...parent::fields(),
         ];

--- a/src/Domain/ProductOptions/JsonApi/V1/ProductOptionSchema.php
+++ b/src/Domain/ProductOptions/JsonApi/V1/ProductOptionSchema.php
@@ -49,9 +49,13 @@ class ProductOptionSchema extends Schema
             Str::make('handle')
                 ->readOnly(),
 
-            HasMany::make('values', 'values')
+            HasMany::make('product_option_values', 'values')
                 ->type(SchemaType::get(ProductOptionValue::class))
-                ->readOnly(),
+                ->canCount()
+                ->countAs('product_option_values_count')
+                ->serializeUsing(
+                    static fn ($relation) => $relation->withoutLinks()
+                ),
 
             ...parent::fields(),
         ];

--- a/src/Domain/ProductOptions/Policies/ProductOptionPolicy.php
+++ b/src/Domain/ProductOptions/Policies/ProductOptionPolicy.php
@@ -61,4 +61,12 @@ class ProductOptionPolicy
 
         return false;
     }
+
+    /**
+     * Authorize a user to view variant's product option values.
+     */
+    public function viewProductOptionValues(?Authenticatable $user, ProductOptionContract $productOption): bool
+    {
+        return true;
+    }
 }

--- a/src/Domain/ProductVariants/Http/Routing/ProductVariantRouteGroup.php
+++ b/src/Domain/ProductVariants/Http/Routing/ProductVariantRouteGroup.php
@@ -31,6 +31,7 @@ class ProductVariantRouteGroup extends RouteGroup implements RouteGroupContract
                         $relationships->hasMany('product')->readOnly();
                         $relationships->hasOne('thumbnail')->readOnly();
                         $relationships->hasMany('urls')->readOnly();
+                        $relationships->hasMany('product_option_values')->readOnly();
                     })
                     ->only('index', 'show')
                     ->readOnly();

--- a/src/Domain/ProductVariants/JsonApi/V1/ProductVariantSchema.php
+++ b/src/Domain/ProductVariants/JsonApi/V1/ProductVariantSchema.php
@@ -133,10 +133,14 @@ class ProductVariantSchema extends Schema
                 ->type(SchemaType::get(Media::class))
                 ->canCount(),
 
-            HasMany::make('values', 'values')
+            HasMany::make('product_option_values', 'values')
+                ->retainFieldName()
                 ->type(SchemaType::get(ProductOptionValue::class))
+                ->readOnly()
+                ->canCount()
+                ->countAs('product_option_values_count')
                 ->serializeUsing(
-                    static fn ($relation) => $relation->withoutLinks(),
+                    static fn ($relation) => $relation->withoutLinks()
                 ),
 
             HasOne::make('default_url', 'defaultUrl')

--- a/src/Domain/ProductVariants/Policies/ProductVariantPolicy.php
+++ b/src/Domain/ProductVariants/Policies/ProductVariantPolicy.php
@@ -119,6 +119,14 @@ class ProductVariantPolicy
     }
 
     /**
+     * Authorize a user to view variant's product option values.
+     */
+    public function viewProductOptionValues(?Authenticatable $user, ProductVariantContract $variant): bool
+    {
+        return true;
+    }
+
+    /**
      * Authorize a user to view variant's thumbnail.
      */
     public function viewThumbnail(?Authenticatable $user, ProductVariantContract $variant): bool

--- a/src/Domain/Products/Http/Routing/ProductRouteGroup.php
+++ b/src/Domain/Products/Http/Routing/ProductRouteGroup.php
@@ -37,6 +37,7 @@ class ProductRouteGroup extends RouteGroup implements RouteGroupContract
                         $relationships->hasOne('thumbnail')->readOnly();
                         $relationships->hasMany('urls')->readOnly();
                         $relationships->hasMany('product_variants')->readOnly();
+                        $relationships->hasMany('product_options')->readOnly();
                     })
                     ->only('index', 'show')
                     ->readOnly();

--- a/src/Domain/Products/JsonApi/V1/ProductSchema.php
+++ b/src/Domain/Products/JsonApi/V1/ProductSchema.php
@@ -193,6 +193,12 @@ class ProductSchema extends Schema
                 ->canCount()
                 ->countAs('product_variants_count'),
 
+            HasMany::make('product_options', 'productOptions')
+                ->retainFieldName()
+                ->type('product_options')
+                ->canCount()
+                ->countAs('product_options_count'),
+
             ...parent::fields(),
         ];
     }

--- a/src/Domain/Products/Policies/ProductPolicy.php
+++ b/src/Domain/Products/Policies/ProductPolicy.php
@@ -189,4 +189,12 @@ class ProductPolicy
     {
         return true;
     }
+
+    /**
+     * Authorize a user to view product's options.
+     */
+    public function viewProductOptions(?Authenticatable $user, ProductContract $product): bool
+    {
+        return true;
+    }
 }

--- a/tests/Feature/Domain/ProductVariants/JsonApi/V1/ProductVariantProductOptionValuesRelationshipTest.php
+++ b/tests/Feature/Domain/ProductVariants/JsonApi/V1/ProductVariantProductOptionValuesRelationshipTest.php
@@ -1,0 +1,69 @@
+<?php
+
+use Dystcz\LunarApi\Domain\Products\Models\Product;
+use Dystcz\LunarApi\Domain\ProductVariants\Models\ProductVariant;
+use Dystcz\LunarApi\Tests\TestCase;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Lunar\Models\ProductOption;
+use Lunar\Models\ProductOptionValue;
+
+uses(TestCase::class, RefreshDatabase::class);
+
+it('can list product options values through relationship', function () {
+    /** @var TestCase $this */
+    $product = Product::factory()
+        ->hasAttached(
+            ProductOption::factory()
+                ->count(2)
+                ->has(ProductOptionValue::factory()->count(3), 'values'),
+            ['position' => 1],
+        )
+        ->create();
+
+    $values = $product->productOptions->map(fn (ProductOption $option) => $option->values->first());
+
+    $variant = ProductVariant::factory()
+        ->for($product, 'product')
+        ->hasAttached($values, [], 'values')
+        ->create();
+
+    $response = $this
+        ->jsonApi()
+        ->expects('product_option_values')
+        ->get(serverUrl("/product_variants/{$variant->getRouteKey()}/product_option_values"));
+
+    $response
+        ->assertSuccessful()
+        ->assertFetchedMany($variant->values)
+        ->assertDoesntHaveIncluded();
+})->group('product-variants');
+
+it('can count product option values', function () {
+    /** @var TestCase $this */
+    $product = Product::factory()
+        ->hasAttached(
+            ProductOption::factory()
+                ->count(2)
+                ->has(ProductOptionValue::factory()->count(3), 'values'),
+            ['position' => 1],
+        )
+        ->create();
+
+    $values = $product->productOptions->map(fn (ProductOption $option) => $option->values->first());
+
+    $variant = ProductVariant::factory()
+        ->for($product, 'product')
+        ->hasAttached($values, [], 'values')
+        ->create();
+
+    $response = $this
+        ->jsonApi()
+        ->expects('product_variants')
+        ->get(serverUrl("/product_variants/{$variant->getRouteKey()}?with_count=product_option_values"));
+
+    $response
+        ->assertSuccessful()
+        ->assertFetchedOne($variant);
+
+    expect($response->json('data.relationships.product_option_values.meta.count'))->toBe(2);
+})->group('product-variants', 'counts');

--- a/tests/Feature/Domain/Products/JsonApi/V1/ProductProductOptionsRelationshipTest.php
+++ b/tests/Feature/Domain/Products/JsonApi/V1/ProductProductOptionsRelationshipTest.php
@@ -1,0 +1,43 @@
+<?php
+
+use Dystcz\LunarApi\Domain\Products\Models\Product;
+use Dystcz\LunarApi\Tests\TestCase;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Lunar\Models\ProductOption;
+
+uses(TestCase::class, RefreshDatabase::class);
+
+it('can list product options through relationship', function () {
+    /** @var TestCase $this */
+    $product = Product::factory()
+        ->hasAttached(ProductOption::factory()->count(2), ['position' => 1])
+        ->create();
+
+    $response = $this
+        ->jsonApi()
+        ->expects('product_options')
+        ->get(serverUrl("/products/{$product->getRouteKey()}/product_options"));
+
+    $response
+        ->assertSuccessful()
+        ->assertFetchedMany($product->productOptions)
+        ->assertDoesntHaveIncluded();
+})->group('products');
+
+it('can count product options', function () {
+    /** @var TestCase $this */
+    $product = Product::factory()
+        ->hasAttached(ProductOption::factory()->count(4), ['position' => 1])
+        ->create();
+
+    $response = $this
+        ->jsonApi()
+        ->expects('products')
+        ->get(serverUrl("/products/{$product->getRouteKey()}?with_count=product_options"));
+
+    $response
+        ->assertSuccessful()
+        ->assertFetchedOne($product);
+
+    expect($response->json('data.relationships.product_options.meta.count'))->toBe(4);
+})->group('products', 'counts');


### PR DESCRIPTION
### Changes

-   Added `product_options` relationship for `products`

### ⚠️ Breaking changes

1. Changed relationship names.

    **Relationships:**

    `product_options.values` → `product_options.product_option_values`
    `product_variants.values` → `product_variants.product_option_values`
